### PR TITLE
feat: broad legal entity scraper on date

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ Small pet project for playing around with [Belgian official journal](https://www
 2. setup the `.env` file by filling in the [.myenv](.myenv) and renaming it to `.env`
 
 ## Running the project
-Activate the virtual environment and then run `scrapy crawl legal-entity-spider`.
+There are two spiders in this repo that can be used to crawl the Belgian Journal.
+1. `legal-entity-vat-spider`: takes a list of vats to scrape
+2. `legal-entity-date-spider`: takes a daterange between which it will scrape (dates included)
+
+Activate the virtual environment and then run `scrapy crawl legal-entity-vat-spider` or `scrapy crawl legal-entity-date-spider -a start_date=2023-01-01 -a end_date=2023-01-07`.
 
 ## Documentation
 There is additional documentation on this project for the following topics:
 - [scraping](documentation/scraping.md)
 - [OCR](documentation/ocr.md)
-- [Text extraction](documentation/extract_text.md)
-
+- [text extraction](documentation/extract_text.md)
 
 ## Visual overview
 ![](documentation/resources/solution.png)

--- a/src/settings.py
+++ b/src/settings.py
@@ -103,7 +103,10 @@ FEED_EXPORT_ENCODING = "utf-8"
 LOG_LEVEL = "INFO"
 ROOT_DIR = Path(__file__).parents[1]
 FILES_STORE = str(ROOT_DIR / "tmp_pdfs")
-CLEANUP = False  # delete file store and blobs in the azure storage (helps for debugging, in prod should be False)
+
+# useful for debugging, should be False in PROD
+CLEANUP_FILESTORE = False  # deletes tmp_pdfs ==> forces redownload of a pdf when not available on BLOB
+CLEANUP_BLOBSTORE = False  # deletes Azure Container content ==> forces Scrapy Item in next run
 
 # AZURE STORAGE SETTINGS
 AZURE_STORAGE_ACCOUNT_KEY = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")

--- a/src/spiders/__init__.py
+++ b/src/spiders/__init__.py
@@ -3,8 +3,10 @@
 # Please refer to the documentation for information on how to create and manage
 # your spiders.
 
-from src.spiders.legal_entities import LegalEntitySpider
+from src.spiders.legal_entities import BaseLegalEntitySpider, LegalEntityDateSpider, LegalEntityVatSpider
 
 __all__ = [
-    "LegalEntitySpider",
+    "BaseLegalEntitySpider",
+    "LegalEntityDateSpider",
+    "LegalEntityVatSpider",
 ]


### PR DESCRIPTION
adds a legal entity scraper that scrapes between a start- and end-date. This collects all publications between that period with both days included.