### PR TITLE
feat: allow for digital pdfs processing only

### DIFF
--- a/src/extract_text.py
+++ b/src/extract_text.py
@@ -126,12 +126,13 @@ async def extract_text_scan(pdf: pymupdf.Document) -> str:
     return text
 
 
-async def extract_text(pdf: pymupdf.Document | str | Path) -> tuple[str, bool]:
+async def extract_text(pdf: pymupdf.Document | str | Path, do_ocr: bool = True) -> tuple[Optional[str], bool]:
     """extracts text from a pdf. If the pdf is digital, the text will be extracted straight from the
     pdf. If  the pdf is a scan, the pdf will be submitted to Azure Document Intelligence OCR
     after which the text is extracted.
 
     :param pdf: pymupdf.Document | str | Path
+    :param do_ocr: boolean if set to False no OCR will be performed when the provided pdf is a scan.
     :return: tuple(text, is_digital)
     """
     if isinstance(pdf, (str, Path)):
@@ -141,8 +142,10 @@ async def extract_text(pdf: pymupdf.Document | str | Path) -> tuple[str, bool]:
     text = extract_text_digital(pdf)
     if text:
         is_digital = True
-    else:
+    elif not text and do_ocr:
         text = await extract_text_scan(pdf)
         is_digital = False
+    else:
+        text, is_digital = None, False
 
     return text, is_digital

--- a/src/settings.py
+++ b/src/settings.py
@@ -104,8 +104,11 @@ LOG_LEVEL = "INFO"
 ROOT_DIR = Path(__file__).parents[1]
 FILES_STORE = str(ROOT_DIR / "tmp_pdfs")
 
+# Perform OCR on scans (cost of $5 per 1000 pages), if set to False drops the scan PDFs.
+OCR = True
+
 # useful for debugging, should be False in PROD
-CLEANUP_FILESTORE = False  # deletes tmp_pdfs ==> forces redownload of a pdf when not available on BLOB
+CLEANUP_FILESTORE = True  # deletes tmp_pdfs ==> forces redownload of a pdf when not available on BLOB
 CLEANUP_BLOBSTORE = False  # deletes Azure Container content ==> forces Scrapy Item in next run
 
 # AZURE STORAGE SETTINGS


### PR DESCRIPTION
There is a cost of $5 per 1000 pages for OCR. This MR allows you to opt-out of processing scan pdfs in order to save on this cost.
I.e. only digital PDFs will be processed when OCR is set to False