### PR TITLE
fix: scraper can now handle 10000+ publications/day

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -83,7 +83,7 @@ AUTOTHROTTLE_ENABLED = True
 # AUTOTHROTTLE_MAX_DELAY = 60
 # The average number of requests Scrapy should be sending in parallel to
 # each remote server
-AUTOTHROTTLE_TARGET_CONCURRENCY = 2.0
+AUTOTHROTTLE_TARGET_CONCURRENCY = 4.0
 # Enable showing throttling stats for every response received:
 # AUTOTHROTTLE_DEBUG = False
 

--- a/src/spiders/legal_entities.py
+++ b/src/spiders/legal_entities.py
@@ -330,6 +330,6 @@ class LegalEntityDateSpider(BaseLegalEntitySpider):
         delta_days = self.end_date - self.start_date
         for i in range(delta_days.days + 1):
             scrape_date = self.start_date + timedelta(days=i)
-            meta = {"start_date": scrape_date, "end_date": scrape_date}
+            meta = {"start_date": scrape_date, "end_date": scrape_date, "page": 1}
             url = self.format_url(meta)
             yield Request(url=url, callback=self.parse, meta=meta)


### PR DESCRIPTION
Current date scraper cannot handle whenever there are more than 10000 publications per day.

This MR adjusts the scraper logic to always work with pagination for date scraping, making it possible for the scraper to process dates with more than 10K publications. 

An example of a day with more than 10K publications is 10th of October 2024:
 - Original way of querying fails: https://www.ejustice.just.fgov.be/cgi_tsv/rech_res.pl?pdd=2024-10-14&pdf=2024-10-14
- New, paginated way works: https://www.ejustice.just.fgov.be/cgi_tsv/list.pl?language=nl&page=1&pdd=2024-10-14&pdf=2024-10-14 