### PR TITLE
feat: add blob index tags for search

### DIFF
--- a/src/pipelines.py
+++ b/src/pipelines.py
@@ -121,12 +121,13 @@ class LegalEntityPipeline:
         meta_path = str(
             Path(item["vat"])
             / str(publication_date.year)
-            / str(publication_date.month)
-            / str(publication_date.day)
+            / f"{publication_date.month:02d}"
+            / f"{publication_date.day:02d}"
             / f"{item['publication_number']}.json"
         )
+        tags = {"vat": vat, "publication_date": publication_date.strftime("%Y-%m-%d"), "status": "unprocessed"}
         blob_client = spider.blob_service_client.get_blob_client(container=spider.azure_container_name, blob=meta_path)
-        blob_client.upload_blob(json.dumps(publication).encode("utf-8"), overwrite=True)
+        blob_client.upload_blob(json.dumps(publication).encode("utf-8"), overwrite=True, tags=tags)
         return item
 
     def close_spider(self, spider: scrapy.Spider):


### PR DESCRIPTION
Allows for more efficient search than O(N), for example incrementally processing of blobs. Instead of having to iterate over all blobs and see if they are present at and output location, or download them and check the data if they have a key with `status=processed`. With index search on tags you can use `container_client.find_blobs_by_tags("status='unprocessed'")`

for more info, see [link](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs?tabs=azure-portal
)